### PR TITLE
Add method get_filename for API compatibility

### DIFF
--- a/classes/class-native-mo.php
+++ b/classes/class-native-mo.php
@@ -45,6 +45,7 @@ class NativeGettextMO extends Gettext_Translations {
   function set_headers ( $headers ) { return false; }
   function get_header ( $header ) { return false; }
   function translate_entry ( &$entry ) { return false; }
+  function get_filename () { return $mo_file; }
 
   static $locale_not_supported_notice_displayed = false;
   static $multiple_loadtextdomain_displayed = false;


### PR DESCRIPTION
Had an issue with Learndash calling MO method get_filename

`Uncaught Error: Call to undefined method NativeMO::get_filename() in /srv/www/wordpress/wp-content/plugins/sfwd-lms/includes/settings/settings-sections/class-ld-settings-section-support-learndash.php:916
Stack trace:
#0 /srv/www/wordpress/wp-includes/class-wp-hook.php(307): LearnDash_Settings_Section_Support_LearnDash->learndash_support_sections_init()
#1 /srv/www/wordpress/wp-includes/plugin.php(191): WP_Hook->apply_filters()
#2 /srv/www/wordpress/wp-content/plugins/sfwd-lms/includes/settings/settings-pages/class-ld-settings-page-support.php(100): apply_filters()
#3 /srv/www/wordpress/wp-content/plugins/sfwd-lms/includes/settings/settings-pages/class-ld-settings-page-support.php(61): LearnDash_Settings_Page_Support->gather_system_details()`